### PR TITLE
Search translated words for context suggestions

### DIFF
--- a/src/utils/translation_manager.py
+++ b/src/utils/translation_manager.py
@@ -61,17 +61,17 @@ class EnhancedTranslationManager(QObject):
             
         # Look for matches in translated text
         for original_word, translation in context_translations.items():
-            # Find potential matches using fuzzy matching
-            positions = self.find_word_positions(translated_text, original_word)
-            
+            # Find potential matches using fuzzy matching against the translation
+            positions = self.find_word_positions(translated_text, translation)
+
             for start_pos, end_pos in positions:
                 match_text = translated_text[start_pos:end_pos]
                 confidence = SequenceMatcher(
-                    None, 
-                    match_text.lower(), 
-                    original_word.lower()
+                    None,
+                    match_text.lower(),
+                    translation.lower()
                 ).ratio()
-                
+
                 if confidence >= self.suggestion_threshold:
                     suggestions.append(TranslationSuggestion(
                         original_word=match_text,

--- a/tests/test_translation_manager.py
+++ b/tests/test_translation_manager.py
@@ -1,0 +1,77 @@
+import sys
+import os
+import types
+
+
+# ---------------------------------------------------------------------------
+# Test stubs for optional dependencies
+# ---------------------------------------------------------------------------
+
+
+class _DummySignal:
+    """Minimal stand-in for PyQt6's pyqtSignal."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):  # pragma: no cover - behaviour not tested
+        pass
+
+
+qtcore = types.ModuleType("PyQt6.QtCore")
+qtcore.QObject = object
+qtcore.pyqtSignal = _DummySignal
+
+pyqt6 = types.ModuleType("PyQt6")
+pyqt6.QtCore = qtcore
+
+sys.modules.setdefault("PyQt6", pyqt6)
+sys.modules.setdefault("PyQt6.QtCore", qtcore)
+
+
+googletrans = types.ModuleType("googletrans")
+
+
+class _Translator:
+    def translate(self, text, src=None, dest=None):  # pragma: no cover - simple stub
+        class _Result:
+            def __init__(self, text):
+                self.text = text
+                self.src = src
+
+        return _Result(text)
+
+
+googletrans.Translator = _Translator
+
+sys.modules.setdefault("googletrans", googletrans)
+
+
+# Ensure the src package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.utils.translation_manager import EnhancedTranslationManager
+
+
+class _DummyKeywordManager:
+    def __init__(self):
+        self.contexts = {
+            "Automotive": {
+                "translations": {"car": "auto"}
+            }
+        }
+
+
+class _DummyPersonalDictionary:
+    def __init__(self):
+        self.keyword_manager = _DummyKeywordManager()
+
+
+def test_context_suggestions_use_translations():
+    manager = EnhancedTranslationManager(_DummyPersonalDictionary(), object())
+
+    translated_text = "The auto is fast"
+    suggestions = manager.get_context_matches(translated_text, "Automotive")
+
+    assert any(s.suggested_word == "auto" for s in suggestions)
+


### PR DESCRIPTION
## Summary
- Look for dictionary translations in translated text when generating context suggestions.
- Adjust confidence calculation to compare against translated terms.
- Add unit test verifying suggestions appear when translated text contains a dictionary translation.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c3e5201c8323b553abf529eee404